### PR TITLE
Allow custom deploy repo using GH_REPO_SLUG env variable

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -126,3 +126,13 @@ def test_deploy_on_pr(builded_doc, travis_env):
     # by default the deploy is not done if we are on a PR
     assert result.exit_code == 0, result.output
     assert result.output == ''
+
+def test_deploy_custom_repo(builded_doc, travis_env):
+    travis_env['GH_REPO_SLUG'] = 'org2/fork-of-travis-sphinx'
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ['-o', builded_doc, 'deploy'], env=travis_env)
+    assert result.exit_code == 0, result.output
+    assert result.output == 'ghp-import -p -f -n -r ' \
+                            'https://token@github.com/org2/fork-of-travis-sphinx.git ' \
+                            '-m Update\ documentation %s\n' % builded_doc

--- a/travis_sphinx/deploy.py
+++ b/travis_sphinx/deploy.py
@@ -36,11 +36,17 @@ def deploy(ctx, branches, cname, message):
     Deploy built docs to gh-pages, uses ``GH_TOKEN`` for pushing built
     documentation files located in *target/doc* to gh
 
+    If the environment variable ``GH_REPO_SLUG`` is set, the docs will be
+    deployed to the specified github repository. Otherwise, the environment
+    variable of the travis build will be used (``TRAVIS_REPO_SLUG``).
+
     """
     branch = os.environ.get('TRAVIS_BRANCH', '')
     pr = os.environ.get('TRAVIS_PULL_REQUEST', '')
     token = os.environ.get('GH_TOKEN', '')
-    repo = os.environ.get('TRAVIS_REPO_SLUG', '')
+    repo = os.environ.get('GH_REPO_SLUG')
+    if repo is None:
+        repo = os.environ.get('TRAVIS_REPO_SLUG', '')
     tag = os.environ.get('TRAVIS_TAG', '')
     is_pytest_mode = 'PYTEST' in os.environ
     outdir = ctx.obj['outdir']


### PR DESCRIPTION
This modification was needed for what may or may not be an typical use case, but I still wanted to share it in case it seemed useful.

I maintain a [project](https://github.com/roger-/pyrtlsdr) that I am not the owner of and cannot directly make certain changes to (the project owner isn't always active and I try to respect that as much as possible).  The docs are set up and hosted through my [fork](https://github.com/nocarryr/pyrtlsdr), so I needed a way to make `build.py` deploy there.

Relevant PR: https://github.com/roger-/pyrtlsdr/pull/82

I welcome your comments/suggestions, etc.  If this isn't something you feel should be part of this project, I can just keep my fork up for my own purposes.