### PR TITLE
Exclude tests from the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/syntaf/travis-sphinx',
     download_url='https://github.com/Syntaf/travis-sphinx/archive/master.zip',
     keywords=['documentation', 'travis', 'python', 'deploy'],
-    packages = find_packages(),
+    packages=find_packages(exclude=('tests',)),
     py_modules = ['travis_sphinx'],
     entry_points = {
         'console_scripts' : ['travis-sphinx=travis_sphinx.main:main']


### PR DESCRIPTION
Currently, test is installed with the package:
```
> ls /usr/local/lib/python3.5/dist-packages/tests/
__init__.py  
test_commands.py  
...
```
This change should remove `tests` from the distributed package