### PR TITLE
Fix for when GH_TOKEN is not set

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -55,7 +55,7 @@ def test_build():
         assert os.path.exists(os.path.join(output_dir, 'index.html'))
 
 
-def test_buid_with_warning():
+def test_build_with_warning():
     runner = CliRunner()
     with runner.isolated_filesystem() as tmpDir:
         # sphinx will issue warnings when generating the documentations.

--- a/travis_sphinx/deploy.py
+++ b/travis_sphinx/deploy.py
@@ -50,7 +50,7 @@ def deploy(ctx, branches, cname, message, deploy_host):
     """
     branch = os.environ.get('TRAVIS_BRANCH', '')
     pr = os.environ.get('TRAVIS_PULL_REQUEST', '')
-    token = os.environ.get('GH_TOKEN', '')
+    token = os.environ.get('GH_TOKEN')
     repo = os.environ.get('GH_REPO_SLUG')
     if repo is None:
         repo = os.environ.get('TRAVIS_REPO_SLUG', '')


### PR DESCRIPTION
The exception was never being thrown because `GH_TOKEN` was never `None`.

Accidentally introduced in https://github.com/Syntaf/travis-sphinx/commit/10e0f2576bfec825c0fd1ab1c2375e59fa1b8298.