### PR TITLE
Default directories should be consistent between source and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ script:
 after_success:
     - travis-sphinx deploy
 ```
-*build* will generate the actual documentation files while *deploy* will move those files to gh-pages. If you don't have your documentation in the standard `docs/source` path, you can specify **where** they are with `--source`. This tool also assumes that you would like to build and deploy the *master* branch and any *tags* pushed. If you would like to point the tool elsewhere, this can be solved using `--branches` , e.g. `travis-sphinx --branches=test,production` will build and deploy on **only** the test and production branches.
+*build* will generate the actual documentation files while *deploy* will move those files to gh-pages. If you don't have your documentation in the standard `doc/source` path, you can specify **where** they are with `--source`. This tool also assumes that you would like to build and deploy the *master* branch and any *tags* pushed. If you would like to point the tool elsewhere, this can be solved using `--branches` , e.g. `travis-sphinx --branches=test,production` will build and deploy on **only** the test and production branches.
 ```
 script:
     - travis-sphinx build --source=other/dir/doc

--- a/travis_sphinx/build.py
+++ b/travis_sphinx/build.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
     '-s', '--source',
     type=click.Path(dir_okay=True, file_okay=False, exists=True),
     help='Source directory of sphinx docs',
-    default='docs/source',
+    default='doc/source',
     show_default=True
 )
 @click.option(


### PR DESCRIPTION
The default top-level for building is `doc`, and most documentation
refers to `doc` rather than `docs`. Switch everything to `doc`.