### PR TITLE
Update README.md to correct the default Source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Usage: travis-sphinx build [OPTIONS]
 
 Options:
   -s, --source DIRECTORY  Source directory of sphinx docs  [default:
-                          doc/source]
+                          docs/source]
   -n, --nowarn BOOLEAN    Do not error on warnings
   --help                  Show this message and exit.
 


### PR DESCRIPTION
The README file had doc/source as the default but docs/source is the actual default the package considers.